### PR TITLE
Add -T|--timestamp flag for showing log timestamps to jebediah cat-stream

### DIFF
--- a/main/jebediah.hs
+++ b/main/jebediah.hs
@@ -71,7 +71,7 @@ commandP' = subparser $
               (ListStreams <$> groupName')
   <> command' "cat-stream"
               "Cat a stream"
-              (Cat <$> groupName' <*> streamName' <*> fromTime' <*> follow')
+              (Cat <$> groupName' <*> streamName' <*> fromTime' <*> follow' <*> timestamp')
   <> command' "create-group"
               "Create a log group"
               (CreateGroup <$> groupName')
@@ -94,10 +94,10 @@ run c = do
        sourceLogGroups Nothing $$ DC.mapM_ (\x -> liftIO $ T.putStrLn `traverse_` (x ^. M.lgLogGroupName))
     ListStreams g ->
        sourceLogStreams g Nothing $$ DC.mapM_ (\x -> liftIO $ T.putStrLn `traverse_` (x ^. M.lsLogStreamName))
-    Cat g s tt f -> liftIO $ do
+    Cat g s tt f tv -> liftIO $ do
        tz <- DT.getCurrentTimeZone
        let tt' = case tt of Nothing -> Everything; Just ttt -> From (DT.localTimeToUTC tz ttt)
-       source e g s tt' f $$ DC.mapM_ (\(Log text _) -> liftIO $ T.putStrLn text)
+       source e g s tt' f $$ DC.mapM_ (writeLog tv)
     CreateGroup g ->
       newLogGroup g
     CreateStream g s ->
@@ -115,15 +115,32 @@ run c = do
       lock <- liftIO $ ExclusiveSequence <$> newMVar (Sequence <$> sn)
       void . liftIO . runResourceT $ getFileConduit fp $$ sink e g s lock
 
+writeLog :: Timestamp -> Log -> IO ()
+writeLog v (Log text time0) =
+  case v of
+    HideTimestamp ->
+      T.putStrLn text
+    ShowTimestamp ->
+      let
+        time =
+          DT.formatTime DT.defaultTimeLocale "%Y-%m-%d %H:%M:%S" time0
+      in
+        T.putStrLn $ T.pack time <> " " <> text
+
 data Command =
-  ListGroups
+    ListGroups
   | ListStreams LogGroup
-  | Cat LogGroup LogStream (Maybe DT.LocalTime) Following
+  | Cat LogGroup LogStream (Maybe DT.LocalTime) Following Timestamp
   | CreateGroup LogGroup
   | CreateStream LogGroup LogStream
   | CreateStreamAndUpload LogGroup LogStream FilePath
   | UploadFile LogGroup LogStream FilePath (Maybe T.Text)
-  deriving (Eq, Show)
+    deriving (Eq, Show)
+
+data Timestamp =
+    HideTimestamp
+  | ShowTimestamp
+    deriving (Eq, Show)
 
 groupName' :: Parser LogGroup
 groupName' = LogGroup <$> argument textRead (metavar "GROUP-NAME")
@@ -144,6 +161,13 @@ fromTime' = optional $ option (pOption p) (short 't' <> long "time" <> help "Loc
 
 follow' :: Parser Following
 follow' = (Follow . seconds) <$> option auto (short 'f' <> long "follow" <> help "Follow the stream with checks every 'X' seconds" <> metavar "X") <|> pure NoFollow
+
+timestamp' :: Parser Timestamp
+timestamp' =
+  flag HideTimestamp ShowTimestamp $
+    short 'T' <>
+    long "timestamp" <>
+    help "Show the timestamp next to each log entry."
 
 getFileConduit :: MonadIO m => FilePath -> Source m Log
 getFileConduit path = do


### PR DESCRIPTION
This fixes https://github.com/ambiata/jebediah/issues/30

Example:
```
2017-07-26 04:50:32 icicle: Compiling TOML -> C
2017-07-26 04:50:32 icicle: Parsing TOML
2017-07-26 04:50:34 icicle: Parsing TOML (took 1.50s)
2017-07-26 04:50:34 icicle: Compiling Source -> Core
2017-07-26 04:50:34 icicle: Compiling Source -> Core (took 0.48s)
2017-07-26 04:50:34 icicle: Fusing Compute Kernels
2017-07-26 04:50:36 icicle: Fusing Compute Kernels (took 1.55s)
2017-07-26 04:50:36 icicle: Compiling Core -> Avalanche
2017-07-26 04:51:49 icicle: Compiling Core -> Avalanche (took 73.20s)
2017-07-26 04:51:49 icicle: Compiling Avalanche -> C
2017-07-26 04:51:49 icicle: Compiling Avalanche -> C (took 0.00s)
2017-07-26 04:51:53 icicle: Compiling TOML -> C (took 81.40s)
```

Open to suggestions on the time formatting to use.

! @nhibberd @phickey 
/jury approved @nhibberd