### PR TITLE
List log streams by last-updated

### DIFF
--- a/main/jebediah.hs
+++ b/main/jebediah.hs
@@ -93,7 +93,7 @@ run c = do
     ListGroups ->
        sourceLogGroups Nothing $$ DC.mapM_ (\x -> liftIO $ T.putStrLn `traverse_` (x ^. M.lgLogGroupName))
     ListStreams g ->
-       sourceLogStreams g Nothing $$ DC.mapM_ (\x -> liftIO $ T.putStrLn `traverse_` (x ^. M.lsLogStreamName))
+       sourceLogStreams g StreamsLatest $$ DC.mapM_ (\x -> liftIO $ T.putStrLn `traverse_` (x ^. M.lsLogStreamName))
     Cat g s tt f tv -> liftIO $ do
        tz <- DT.getCurrentTimeZone
        let tt' = case tt of Nothing -> Everything; Just ttt -> From (DT.localTimeToUTC tz ttt)

--- a/src/Jebediah/Data.hs
+++ b/src/Jebediah/Data.hs
@@ -8,6 +8,7 @@ module Jebediah.Data (
   , ExclusiveSequence (..)
   , Log (..)
   , Query (..)
+  , StreamOutput (..)
   , sizeOf
   , utcToUnix
   , unixToUtc
@@ -73,6 +74,11 @@ data Query =
   | Between UTCTime UTCTime
   | At Sequence
     deriving (Eq, Show)
+
+data StreamOutput =
+    StreamsLatest
+  | StreamsPrefix (Maybe LogStream)
+  deriving (Eq, Show)
 
 -- |
 -- 26 bytes of overhead per event plus size of data


### PR DESCRIPTION
I think it makes sense to make this the default ordering in the CLI;
getting the whole list ordered by stream name is not very useful for
operational purposes.

! @nhibberd @HuwCampbell